### PR TITLE
Update Javadoc workflow to work without a PAT

### DIFF
--- a/.github/workflows/create-javadoc.yml
+++ b/.github/workflows/create-javadoc.yml
@@ -45,19 +45,20 @@ jobs:
           cd ${GITHUB_WORKSPACE}/newrelic-java-agent/newrelic-api 
           ../gradlew javadoc $GRADLE_OPTIONS -Prelease=true -PagentVersion=${{ inputs.version }}
       
-      - name: Checkout and push api/javadoc
+      - name: Checkout api/javadoc
         uses: actions/checkout@v3
         with:
-          repository: newrelic/java-agent-api
           ref: gh-pages
           path: java-agent-api
-          run: |
+
+      - name: Update contents and push api/javadoc
+        run: |
+            git config --global user.email ${{ env.EMAIL }}
+            git config --global user.name "newrelic-java-agent-team"
             cd ${GITHUB_WORKSPACE}
             rm -r java-agent-api/javadoc
             mv newrelic-java-agent/newrelic-api/build/docs/javadoc java-agent-api
             cd java-agent-api
-            git config --global user.email ${{ env.EMAIL }}
-            git config --global user.name "newrelic-java-agent-team"
             git add javadoc
             git commit -m 'Updating to v${{ inputs.version }}'
             git push

--- a/.github/workflows/create-javadoc.yml
+++ b/.github/workflows/create-javadoc.yml
@@ -63,7 +63,6 @@ jobs:
           cd java-agent-api
           git config --global user.email ${{ env.EMAIL }}
           git config --global user.name "newrelic-java-agent-team"
-          git remote set-url origin https://x-access-token:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY
           git add javadoc
           git commit -m 'Updating to v${{ inputs.version }}'
-          git push origin gh-pages
+          git push

--- a/.github/workflows/create-javadoc.yml
+++ b/.github/workflows/create-javadoc.yml
@@ -60,14 +60,11 @@ jobs:
           mv newrelic-java-agent/newrelic-api/build/docs/javadoc java-agent-api
 
       - name: Commit Javadoc Changes & Push New Branch
-        env:
-         GITHUB_TOKEN: ${{ secrets.JAVADOC_TOKEN }}
         run: |
           cd java-agent-api
           git config --global user.email ${{ env.EMAIL }}
           git config --global user.name "newrelic-java-agent-team"
-          git remote set-url origin https://x-access-token:${{ secrets.JAVADOC_TOKEN }}@github.com/$GITHUB_REPOSITORY
+          git remote set-url origin https://x-access-token:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY
           git add javadoc
           git commit -m 'Updating to v${{ inputs.version }}'
-          git push origin gh-pages:v${{ inputs.version }}
-          gh pr create -B gh-pages -H v${{ inputs.version }} --title 'Merging v${{ inputs.version }} of javadocs' --body 'Merging v${{ inputs.version }} of javadocs'
+          git push origin gh-pages

--- a/.github/workflows/create-javadoc.yml
+++ b/.github/workflows/create-javadoc.yml
@@ -45,25 +45,19 @@ jobs:
           cd ${GITHUB_WORKSPACE}/newrelic-java-agent/newrelic-api 
           ../gradlew javadoc $GRADLE_OPTIONS -Prelease=true -PagentVersion=${{ inputs.version }}
       
-      - name: Checkout api/javadoc
+      - name: Checkout and push api/javadoc
         uses: actions/checkout@v3
         with:
           repository: newrelic/java-agent-api
           ref: gh-pages
           path: java-agent-api
-
-      - name: Relocate Javadoc
-        run: |
-          cd ${GITHUB_WORKSPACE}
-          rm -r java-agent-api/javadoc
-          mv newrelic-java-agent/newrelic-api/build/docs/javadoc java-agent-api
-
-      - name: Commit Javadoc Changes & Push New Branch
-        run: |
-          cd java-agent-api
-          git config --global user.email ${{ env.EMAIL }}
-          git config --global user.name "newrelic-java-agent-team"
-          git remote set-url origin https://x-access-token:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY
-          git add javadoc
-          git commit -m 'Updating to v${{ inputs.version }}'
-          git push
+          run: |
+            cd ${GITHUB_WORKSPACE}
+            rm -r java-agent-api/javadoc
+            mv newrelic-java-agent/newrelic-api/build/docs/javadoc java-agent-api
+            cd java-agent-api
+            git config --global user.email ${{ env.EMAIL }}
+            git config --global user.name "newrelic-java-agent-team"
+            git add javadoc
+            git commit -m 'Updating to v${{ inputs.version }}'
+            git push

--- a/.github/workflows/create-javadoc.yml
+++ b/.github/workflows/create-javadoc.yml
@@ -51,7 +51,6 @@ jobs:
           repository: newrelic/java-agent-api
           ref: gh-pages
           path: java-agent-api
-          token: ${{ secrets.JAVADOC_TOKEN }}
 
       - name: Relocate Javadoc
         run: |

--- a/.github/workflows/create-javadoc.yml
+++ b/.github/workflows/create-javadoc.yml
@@ -61,8 +61,10 @@ jobs:
       - name: Commit Javadoc Changes & Push New Branch
         run: |
           cd java-agent-api
-          git config --global user.email ${{ env.EMAIL }}
-          git config --global user.name "newrelic-java-agent-team"
+          # git config --global user.email ${{ env.EMAIL }}
+          # git config --global user.name "newrelic-java-agent-team"
+          git config user.name github-actions
+          git config user.email github-actions@github.com
           git add javadoc
           git commit -m 'Updating to v${{ inputs.version }}'
           git push

--- a/.github/workflows/create-javadoc.yml
+++ b/.github/workflows/create-javadoc.yml
@@ -22,7 +22,7 @@ jobs:
           distribution: 'temurin'
           java-version: 17
 
-      - name: Checkout
+      - name: Checkout agent
         uses: actions/checkout@v3
         with:
           repository: newrelic/newrelic-java-agent
@@ -45,7 +45,7 @@ jobs:
           cd ${GITHUB_WORKSPACE}/newrelic-java-agent/newrelic-api 
           ../gradlew javadoc $GRADLE_OPTIONS -Prelease=true -PagentVersion=${{ inputs.version }}
       
-      - name: Checkout
+      - name: Checkout api/javadoc
         uses: actions/checkout@v3
         with:
           repository: newrelic/java-agent-api
@@ -61,10 +61,9 @@ jobs:
       - name: Commit Javadoc Changes & Push New Branch
         run: |
           cd java-agent-api
-          # git config --global user.email ${{ env.EMAIL }}
-          # git config --global user.name "newrelic-java-agent-team"
-          git config user.name github-actions
-          git config user.email github-actions@github.com
+          git config --global user.email ${{ env.EMAIL }}
+          git config --global user.name "newrelic-java-agent-team"
+          git remote set-url origin https://x-access-token:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY
           git add javadoc
           git commit -m 'Updating to v${{ inputs.version }}'
           git push


### PR DESCRIPTION
Simplifies this workflow to not depend on a token that is linked to a user.
Now it will use the workflow provided token.

Also removed the PR creation, now the workflow will commit directly to the `gh-pages` branch.
The PR used to be created so someone had to validate the contents of the commit prior to merging.
Since this workflow has been used a few times without a problem, that step is no longer necessary.