### PR TITLE
Update create-javadoc.yml

### DIFF
--- a/.github/workflows/create-javadoc.yml
+++ b/.github/workflows/create-javadoc.yml
@@ -17,6 +17,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1 # detects minimum permissions required to run the workflow, uncomment to use
       - name: Set Up Java 17
         uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # pin@v4
         with:


### PR DESCRIPTION
Adds the permissions monitor action which tracks the usage of the temporary GitHub repository token and gives recommendations on the minimum permissions required to run the workflow based on the actual detected workflow activity.

Can be disabled once permissions have been determined and explicitly configured in the workflow.